### PR TITLE
WF-29 [server] Connect Backend&Frontend in EC2 instance

### DIFF
--- a/wafflow/uwsgi_params
+++ b/wafflow/uwsgi_params
@@ -1,0 +1,17 @@
+uwsgi_param  QUERY_STRING       $query_string;
+uwsgi_param  REQUEST_METHOD     $request_method;
+uwsgi_param  CONTENT_TYPE       $content_type;
+uwsgi_param  CONTENT_LENGTH     $content_length;
+
+uwsgi_param  REQUEST_URI        $request_uri;
+uwsgi_param  PATH_INFO          $document_uri;
+uwsgi_param  DOCUMENT_ROOT      $document_root;
+uwsgi_param  SERVER_PROTOCOL    $server_protocol;
+uwsgi_param  REQUEST_SCHEME     $scheme;
+uwsgi_param  HTTPS              $https if_not_empty;
+
+uwsgi_param  REMOTE_ADDR        $remote_addr;
+uwsgi_param  REMOTE_PORT        $remote_port;
+uwsgi_param  SERVER_PORT        $server_port;
+uwsgi_param  SERVER_NAME        $server_name;
+

--- a/wafflow/wafflow-server_uwsgi.ini
+++ b/wafflow/wafflow-server_uwsgi.ini
@@ -1,0 +1,26 @@
+[uwsgi]
+# Django-related settings
+# base directory
+chdir = /home/ec2-user/wafflow/team4-server/wafflow
+module = wafflow-server.wsgi:application
+
+# virtualenv
+home = /home/ec2-user/.pyenv/versions/venv_wafflow
+virtualenv = /home/ec2-user/.pyenv/versions/venv_wafflow
+
+socket = /home/ec2-user/wafflow-server_uwsgi.sock
+chmod-socket = 666
+
+# process-related settings
+master = true
+processes = 4
+enable-threads = true
+pidfile = /tmp/wafflow-server_uwsgi.pid
+
+vacuum = true
+daemonize = /home/ec2-user/wafflow-server_uwsgi.log
+lazy-apps = true
+
+buffer-size = 65535
+max-requests = 500
+

--- a/wafflow/wafflow-server_uwsgi.ini
+++ b/wafflow/wafflow-server_uwsgi.ini
@@ -2,7 +2,7 @@
 # Django-related settings
 # base directory
 chdir = /home/ec2-user/wafflow/team4-server/wafflow
-module = wafflow-server.wsgi:application
+module = wafflow.wsgi:application
 
 # virtualenv
 home = /home/ec2-user/.pyenv/versions/venv_wafflow


### PR DESCRIPTION
# Major Changes
> [Trello WF-29](https://trello.com/c/VK4ZMTcq)

<br>

## 1. AWS EC2 인스턴스 생성
- EC2 인스턴스 : **wafflow-server** 생성
- t2.micro version / Amazon Linux 2 AMI (HVM), SSD Volume Type

<br>

## 2. AWS RDS 인스턴스 생성
- RDS 인스턴스 : **wafflow** (엔드포인트 : wafflow.{XXXXXXXXX}.ap-northeast-2.rds.amazonaws.com)
- t2.micro version / PostgreSQL

<br>

## 3. EC2 인스턴스에 git, python, nginx, uwsgi, node 설치
- `bash deploy.sh` 실행 시 자동으로 git에서 최신 상태의 main(master) branch 업데이트 및 배포가 진행됨.

<br>

## 4. 가비아에서 DNS 구입
- http://www.wafflow.com 으로 접속가능.
- 오늘 중으로 443번 포트를 열어 https SSL 인증서 발급 후 자동으로 https://www.wafflow.com으로 리다이렉트시킬 예정.
