### PR TITLE
WF-37 [back] user login token expire logic, user add tag_count, users add user_count

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ asgiref==3.3.1
 astroid==2.4.2
 black==20.8b1
 boto3==1.4.1
+botocore==1.4.93
 certifi==2020.12.5
 cfgv==3.2.0
 chardet==4.0.0
@@ -10,12 +11,14 @@ click==7.1.2
 distlib==0.3.1
 Django==3.1.4
 django-cors-headers==3.6.0
-djangorestframework==3.12.2
 django-storages==1.5.1
+djangorestframework==3.12.2
+docutils==0.16
 filelock==3.0.12
 identify==1.5.10
 idna==2.10
 isort==5.6.4
+jmespath==0.10.0
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
 mypy-extensions==0.4.3
@@ -25,10 +28,12 @@ Pillow==8.0.1
 pre-commit==2.9.3
 psycopg2-binary==2.8.6
 pylint==2.6.0
+python-dateutil==2.8.1
 pytz==2020.4
 PyYAML==5.3.1
 regex==2020.11.13
 requests==2.25.1
+s3transfer==0.1.13
 six==1.15.0
 sqlparse==0.4.1
 toml==0.10.2

--- a/wafflow/user/serializers.py
+++ b/wafflow/user/serializers.py
@@ -6,6 +6,7 @@ from rest_framework.authtoken.models import Token
 from user.models import UserProfile
 from answer.models import Answer
 from question.models import Question, UserQuestion
+from tag.models import UserTag
 from rest_framework.validators import UniqueValidator
 from user.constants import *
 
@@ -131,6 +132,7 @@ class UserProfileSerializer(serializers.ModelSerializer):
     answer_count = serializers.SerializerMethodField()
     bookmark_count = serializers.SerializerMethodField()
     question_count = serializers.SerializerMethodField()
+    tag_count = serializers.SerializerMethodField()
 
     # only for drf
     password = serializers.CharField(write_only="True")
@@ -155,6 +157,7 @@ class UserProfileSerializer(serializers.ModelSerializer):
             "title",
             "intro",
             "github_token",
+            "tag_count",
         )
 
     def get_answer_count(self, user_profile):
@@ -167,6 +170,9 @@ class UserProfileSerializer(serializers.ModelSerializer):
         return UserQuestion.objects.filter(
             user=user_profile.user, bookmark=True, question__is_active=True
         ).count()
+
+    def get_tag_count(self, user_profile):
+        return UserTag.objects.filter(user=user_profile.user).count()
 
     def validate(self, attrs):
         raise serializers.ValidationError(

--- a/wafflow/user/tests.py
+++ b/wafflow/user/tests.py
@@ -130,6 +130,7 @@ class UserTestSetting(TestCase):
         self.assertEqual(data["question_count"], 0)
         self.assertEqual(data["answer_count"], 0)
         self.assertEqual(data["bookmark_count"], 0)
+        self.assertEqual(data["tag_count"], 0)
 
     def check_guzus_after_activites(self, data):
         self.assertIn("id", data)
@@ -146,6 +147,7 @@ class UserTestSetting(TestCase):
         self.assertEqual(data["question_count"], self.guzus_QUESTION_COUNT)
         self.assertEqual(data["answer_count"], 0)
         self.assertEqual(data["bookmark_count"], 0)
+        self.assertEqual(data["tag_count"], 0)
 
     def check_eldpswp99_after_activites(self, data):
         self.assertIn("id", data)
@@ -162,6 +164,7 @@ class UserTestSetting(TestCase):
         self.assertEqual(data["question_count"], 0)
         self.assertEqual(data["answer_count"], self.eldpswp99_ANSWER_COUNT)
         self.assertEqual(data["bookmark_count"], 0)
+        self.assertEqual(data["tag_count"], 0)
 
     def check_YeonghyeonKo_after_activites(self, data):
         self.assertIn("id", data)
@@ -178,6 +181,7 @@ class UserTestSetting(TestCase):
         self.assertEqual(data["question_count"], 0)
         self.assertEqual(data["answer_count"], 0)
         self.assertEqual(data["bookmark_count"], self.YeonghyeonKo_BOOKMARK_COUNT)
+        self.assertEqual(data["tag_count"], 0)
 
 
 class PostUserTestCase(UserTestSetting):
@@ -301,6 +305,7 @@ class PostUserTestCase(UserTestSetting):
         self.assertEqual(data["question_count"], 0)
         self.assertEqual(data["answer_count"], 0)
         self.assertEqual(data["bookmark_count"], 0)
+        self.assertEqual(data["tag_count"], 0)
 
         user_count = User.objects.count()
         self.assertEqual(user_count, 2)
@@ -555,6 +560,7 @@ class PutUserMeTestCase(UserTestSetting):
         self.assertEqual(data["question_count"], 0)
         self.assertEqual(data["answer_count"], 0)
         self.assertEqual(data["bookmark_count"], 0)
+        self.assertEqual(data["tag_count"], 0)
 
 
 class DeleteUserMeTestCase(UserTestSetting):


### PR DESCRIPTION
resolve #33 

user tag_count
users에서 user_count 추가하였습니다

token expire로직은 drf 홈페이지에서 HTTPS의 사용이 필요하다는 것 이외에 딱히 언급사항이 없고, 프론트에서 authentication이 필요할 때마다 토큰 expired여부를 체크하고 다시 요청하고.. 그런 로직이 추가되어야 하는데 지금 추가하기에는 약간 무리라는 생각이 들어 logout이 되면 token을 삭제하는 것만 추가하였습니다. 그리고 기존에 login,logout함수를 이용하였는데, 이 함수 내부를 봤을 때, 세션 로그인 방식을 사용하고 있고, 토큰 로그인 방식을 활용하면서 세션에 굳이 로그인 정보를 저장할 필요가 없다고 생각되어서 삭제했습니다. 이후 테스트해봤을 때 크게 문제가 없어 진행하였습니다. 혹시 이 부분에 대해서 알고 계신 부분이 있다면 조언 부탁드립니다. 로그아웃은 [drf logoutview](https://github.com/Tivix/django-rest-auth/blob/master/rest_auth/views.py)참고하여 작성하였습니다